### PR TITLE
Improve origin matching in CORS

### DIFF
--- a/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
+++ b/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
@@ -56,27 +56,27 @@ export function generateIsOriginAllowed(allowedOrigins: unknown, logger?: Logger
         // TODO: improve host matching if needed, e.g. by using
         // https://github.com/validatorjs/validator.js/blob/master/src/lib/isFQDN.js
 
-        if (!normalisedAllowedOrigin.includes('*')) {
-            if (allowedOriginLookup[normalisedAllowedOrigin]) {
+        if (normalisedAllowedOrigin.includes('*')) {
+            if (normalisedAllowedOrigin.lastIndexOf('*') !== 0) {
+                logger?.warn(
+                    `Ignoring allowedOrigins → "${allowedOrigin}" (only patterns like "*.example.com" or "*--demo.example.com" are supported)`
+                );
+                continue;
+            }
+
+            const normalisedAllowedOriginEnding = normalisedAllowedOrigin.substring(1);
+            if (normalisedAllowedOrigin) {
                 logger?.warn(`Duplicate value in allowedOrigins: "${allowedOrigin}"`);
             } else {
-                allowedOriginLookup[normalisedAllowedOrigin] = true;
+                allowedOriginEndingLookup[normalisedAllowedOriginEnding] = true;
             }
             continue;
         }
 
-        if (normalisedAllowedOrigin.lastIndexOf('*') !== 0) {
-            logger?.warn(
-                `Ignoring allowedOrigins → "${allowedOrigin}" (only values like "*.example.com" or "*--demo.example.com" are supported)`
-            );
-            continue;
-        }
-
-        const normalisedAllowedOriginEnding = normalisedAllowedOrigin.substring(1);
-        if (normalisedAllowedOrigin) {
+        if (allowedOriginLookup[normalisedAllowedOrigin]) {
             logger?.warn(`Duplicate value in allowedOrigins: "${allowedOrigin}"`);
         } else {
-            allowedOriginEndingLookup[normalisedAllowedOriginEnding] = true;
+            allowedOriginLookup[normalisedAllowedOrigin] = true;
         }
     }
 

--- a/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
+++ b/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
@@ -1,0 +1,87 @@
+import { Logger } from 'winston';
+
+type IsOriginAllowed = (origin: string | undefined) => boolean;
+
+export function generateIsOriginAllowed(allowedOrigins: unknown, logger: Logger): IsOriginAllowed {
+    const allowedOriginLookup: Record<string, true> = {};
+    const allowedOriginEndingLookup: Record<string, true> = {};
+
+    if (!Array.isArray(allowedOrigins)) {
+        logger.warn('Expected allowedOrigins to be an array. Allowing all origins.');
+        return () => true;
+    }
+
+    for (const allowedOrigin of allowedOrigins) {
+        if (typeof allowedOrigin !== 'string') {
+            logger.warn(`Ignoring allowedOrigins → ${allowedOrigin} (expected a string)`);
+            continue;
+        }
+
+        const normalisedAllowedOrigin = allowedOrigin.replace(/\s/g, '').toLowerCase();
+        if (!normalisedAllowedOrigin.length) {
+            logger.warn(`Ignoring allowedOrigins → "${allowedOrigin}" (expected a non-empty string)`);
+            continue;
+        }
+
+        if (normalisedAllowedOrigin !== allowedOrigin) {
+            logger.warn(
+                `Ignoring allowedOrigins → "${allowedOrigin}" (expected a normalised string: "${normalisedAllowedOrigin}")`
+            );
+            continue;
+        }
+
+        // TODO: improve host matching if needed, e.g. by using
+        // https://github.com/validatorjs/validator.js/blob/master/src/lib/isFQDN.js
+
+        if (!normalisedAllowedOrigin.includes('*')) {
+            if (allowedOriginLookup[normalisedAllowedOrigin]) {
+                logger.warn(`Duplicate value in allowedOrigins: "${allowedOrigin}"`);
+            } else {
+                allowedOriginLookup[normalisedAllowedOrigin] = true;
+            }
+        }
+
+        if (normalisedAllowedOrigin.lastIndexOf('*') !== 0) {
+            logger.warn(
+                `Ignoring allowedOrigins → "${allowedOrigin}" (only values like "*.example.com" or "*--demo.example.com" are supported)`
+            );
+            continue;
+        }
+
+        const normalisedAllowedOriginEnding = normalisedAllowedOrigin.substring(1);
+        if (normalisedAllowedOrigin) {
+            logger.warn(`Duplicate value in allowedOrigins: "${allowedOrigin}"`);
+        } else {
+            allowedOriginEndingLookup[normalisedAllowedOriginEnding] = true;
+        }
+    }
+
+    const allowedOriginEndings = Object.keys(allowedOriginEndingLookup);
+
+    if (!allowedOriginEndings.length && !Object.keys(allowedOriginLookup).length) {
+        logger.warn('No valid values found in allowedOrigins. Allowing all origins.');
+        return () => true;
+    }
+
+    return (origin) => {
+        // Allow requests with no origin, e.g., like mobile apps or curl requests
+        if (!origin) {
+            return true;
+        }
+
+        // Exact match
+        if (allowedOriginLookup[origin]) {
+            return true;
+        }
+
+        // Ending match
+        for (const allowedOriginEnding of allowedOriginEndings) {
+            if (origin.endsWith(allowedOriginEnding)) {
+                return true;
+            }
+        }
+
+        // No match
+        return false;
+    };
+}

--- a/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
+++ b/infrastructure-api/src/middleware/generateIsOriginAllowed.ts
@@ -62,6 +62,7 @@ export function generateIsOriginAllowed(allowedOrigins: unknown, logger?: Logger
             } else {
                 allowedOriginLookup[normalisedAllowedOrigin] = true;
             }
+            continue;
         }
 
         if (normalisedAllowedOrigin.lastIndexOf('*') !== 0) {

--- a/infrastructure-api/src/middleware/global.middleware.ts
+++ b/infrastructure-api/src/middleware/global.middleware.ts
@@ -12,7 +12,10 @@ import { configureGithubStrategy } from './passport-github';
 import { UserService } from '../services/user.service';
 import { DIContainer } from '../services/config/inversify.config';
 import { TYPES } from '../services/config/types';
+import { generateIsOriginAllowed } from './generateIsOriginAllowed';
 import { IUser } from '../infrastructure/user/user.interface';
+
+const isOriginAllowed = generateIsOriginAllowed(config.get('allowOrigins'), logger);
 
 function GlobalMiddleware(app: express.Application) {
     logger.info('Initialize global middleware.');
@@ -72,13 +75,7 @@ function GlobalMiddleware(app: express.Application) {
                 // Allow all
                 // return callback(null, true);
 
-                const allowedOrigins: string[] = config.get('allowOrigins');
-                // allow requests with no origin, e.g., like mobile apps or curl requests
-                if (!origin) {
-                    logger.debug(`GlobalMiddleware: origin = ${origin}, allowed`);
-                    return callback(null, true);
-                }
-                if (allowedOrigins.indexOf(origin) !== -1) {
+                if (isOriginAllowed(origin)) {
                     logger.debug(`GlobalMiddleware: origin = ${origin}, allowed`);
                     return callback(null, true);
                 } else {


### PR DESCRIPTION
Closes #23 

Supporting all kids of regexps can open a can of worms and can be potentially dangerous. I’ve added support of suffixes with `*` as a wildcard. See function comment for more details.

(please squash when merging)