### PR TITLE
Uncertainty Filenames Changed

### DIFF
--- a/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
+++ b/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
@@ -9,12 +9,12 @@ import app.controllers.uncertainty_analysis.uncertainty_mean_sample as ums
 
 from app.core.settings import DATA_PATH_LIVE
 
-raw_clusters = [{"filename": "models/uncertainty/example/raw-k3-E.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k3_E.json"},
-                {"filename": "models/uncertainty/example/raw-k4-E.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k4_E.json"},
-                {"filename": "models/uncertainty/example/raw-k5-E.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k5_E.json"},
+raw_clusters = [{"filename": "models/uncertainty/example/raw_k3_e.json",
+                 "output_filename": "models/uncertainty/example/mean_all_k3_e.json"},
+                {"filename": "models/uncertainty/example/raw_k4_e.json",
+                 "output_filename": "models/uncertainty/example/mean_all_k4_e.json"},
+                {"filename": "models/uncertainty/example/raw_k5_e.json",
+                 "output_filename": "models/uncertainty/example/mean_all_k5_e.json"},
                 ]
 
 

--- a/data-api/app/controllers/uncertainty_clustering_agent.py
+++ b/data-api/app/controllers/uncertainty_clustering_agent.py
@@ -14,19 +14,19 @@ from app.core.settings import DATA_PATH_LIVE
 
 clusters = [{"metric": 'euclidean',
              "filename": "models/uncertainty/example/raw.json",
-             "output_filename": "models/uncertainty/example/raw-k3-E.json",
+             "output_filename": "models/uncertainty/example/raw_k3_e.json",
              "k": 3,
              "model": "example"},
 
             {"metric": 'euclidean',
              "filename": "models/uncertainty/example/raw.json",
-             "output_filename": "models/uncertainty/example/raw-k4-E.json",
+             "output_filename": "models/uncertainty/example/raw_k4_e.json",
              "k": 4,
              "model": "example"},
 
             {"metric": 'euclidean',
              "filename": "models/uncertainty/example/raw.json",
-             "output_filename": "models/uncertainty/example/raw-k5-E.json",
+             "output_filename": "models/uncertainty/example/raw_k5_e.json",
              "k": 5,
              "model": "example"
              }


### PR DESCRIPTION
Modified filenames so files they can be accessed with https://vis.scrc.uk/stat/v1/data/?product=models/uncertainty/example&component=raw-k3-e etc. the same way https://vis.scrc.uk/stat/v1/data/?product=models/uncertainty/example&component=raw works.