### PR TITLE
Uncertainty analysis dataset inventory

### DIFF
--- a/data-api/app/controllers/uncertainty_analysis/uncertainty_model_inventory.py
+++ b/data-api/app/controllers/uncertainty_analysis/uncertainty_model_inventory.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+from app.core.settings import DATA_PATH_LIVE
+from typing import List
+
+def get_uncertainty_models() -> List[dict]:
+    """Parses the inventory file, containing information on what models and clusterings are present. 
+    
+    Returns:
+        model_list: List where each entry is a dictionary with information regarding a model. The dictionary contains keys:
+            k: List of the clusters which should be computed.
+            name: name of the model, must match the name of the folder where the raw.json for the model is stored.
+            metric: List containing the metrics to be used to find clusters. Allowed options are: euclidean, dtw.
+    """
+    filename_model_list = Path(DATA_PATH_LIVE) / "models/uncertainty/uncertainty_inventory.json"
+    
+    if not filename_model_list.is_file():
+        print("CANNOT FIND ", filename_model_list)
+        return
+    with open(filename_model_list) as f:
+        model_list = json.load(f)
+    return model_list

--- a/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
+++ b/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 import threading
 import json
 from loguru import logger
@@ -9,16 +10,8 @@ import app.controllers.uncertainty_analysis.uncertainty_mean_sample as ums
 
 from app.core.settings import DATA_PATH_LIVE
 
-raw_clusters = [{"filename": "models/uncertainty/example/raw_k3_e.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k3_e.json"},
-                {"filename": "models/uncertainty/example/raw_k4_e.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k4_e.json"},
-                {"filename": "models/uncertainty/example/raw_k5_e.json",
-                 "output_filename": "models/uncertainty/example/mean_all_k5_e.json"},
-                ]
 
-
-def clusters_mean_sample():
+def clusters_mean_sample(raw_clusters):
     """Computes the mean of a group of time series and draws a random sample for plotting.
     """
 
@@ -41,14 +34,46 @@ def clusters_mean_sample():
                              imported["model"])  # Save the processed data
 
 
+def get_cluster_list(model_list: List[dict]) -> List[dict]:
+    """Form a list of dictionaries containing the information needed to compute clusters, based on the information in model_list.
+
+    Args:
+        model_list: List containing a dictionary with: the name, k-values, and distance metrics to be used for cluster analysis of model data.
+    """
+    models = model_list
+    cluster_list = []
+    metric_abbreviation = {"euclidean": "e", "dtw": "dtw"}
+    for model in models:
+        for i in model["k"]:
+            for metric in model["metric"]:
+                cluster_list.append(
+                    {"filename": "models/uncertainty/" + model["name"] + "/raw_k" + str(i) + "_" + metric_abbreviation[metric] + ".json",
+                     "output_filename": "models/uncertainty/" + model["name"] + "/mean_all_k" + str(i) + "_" + metric_abbreviation[metric] + ".json"}
+                )
+    return cluster_list
+
+
+def uncertainty_cluster_mean_sample_agent():
+    filename_model_list = Path(DATA_PATH_LIVE) / "models/uncertainty/uncertainty_inventory.json"
+
+    if not filename_model_list.is_file():
+        print("CANNOT FIND ", filename_model_list)
+        return
+    with open(filename_model_list) as f:
+        model_list = json.load(f)
+        
+    list_of_clusters = get_cluster_list(model_list)
+    clusters_mean_sample(list_of_clusters)
+
+
 # A recurrent job
 scheduler = BackgroundScheduler(daemon=True)
 
 # Cron runs at 1am daily
-scheduler.add_job(clusters_mean_sample, "cron", hour=1, minute=0, second=0)
+scheduler.add_job(uncertainty_cluster_mean_sample_agent, "cron", hour=1, minute=0, second=0)
 
 scheduler.start()
 logger.info('Uncertainty-clustering-agent starts. Will run immediately now and every 1am.')
 
 # Run immediately after server starts
-threading.Thread(target=clusters_mean_sample).start()
+threading.Thread(target=uncertainty_cluster_mean_sample_agent).start()

--- a/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
+++ b/data-api/app/controllers/uncertainty_cluster_mean_sample_agent.py
@@ -7,6 +7,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 import app.controllers.uncertainty_analysis.clustering_tools as ct
 import app.controllers.uncertainty_analysis.uncertainty_mean_sample as ums
+import app.controllers.uncertainty_analysis.uncertainty_model_inventory as inventory
 
 from app.core.settings import DATA_PATH_LIVE
 
@@ -54,14 +55,7 @@ def get_cluster_list(model_list: List[dict]) -> List[dict]:
 
 
 def uncertainty_cluster_mean_sample_agent():
-    filename_model_list = Path(DATA_PATH_LIVE) / "models/uncertainty/uncertainty_inventory.json"
-
-    if not filename_model_list.is_file():
-        print("CANNOT FIND ", filename_model_list)
-        return
-    with open(filename_model_list) as f:
-        model_list = json.load(f)
-        
+    model_list = inventory.get_uncertainty_models()
     list_of_clusters = get_cluster_list(model_list)
     clusters_mean_sample(list_of_clusters)
 

--- a/data-api/app/controllers/uncertainty_clustering_agent.py
+++ b/data-api/app/controllers/uncertainty_clustering_agent.py
@@ -8,6 +8,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from sandu.data_types import UncertaintyInput
 
 import app.controllers.uncertainty_analysis.clustering_tools as ct
+import app.controllers.uncertainty_analysis.uncertainty_model_inventory as inventory
 
 from app.core.settings import DATA_PATH_LIVE
 
@@ -46,6 +47,8 @@ def get_cluster_list(model_list: List[dict]) -> List[dict]:
     Args:
         model_list: List containing a dictionary with: the name, k-values, and distance metrics to be used for cluster analysis of model data.
         
+    Returns:
+        cluster_list: A list containing a dictionary with information on each cluster needed to form the clusters.
     
     """
     models = model_list
@@ -65,16 +68,9 @@ def get_cluster_list(model_list: List[dict]) -> List[dict]:
 
 
 def uncertainty_clustering_agent():
-    filename_model_list = Path(DATA_PATH_LIVE) / "models/uncertainty/uncertainty_inventory.json"
-    
-    if not filename_model_list.is_file():
-        print("CANNOT FIND ", filename_model_list)
-        return
-    with open(filename_model_list) as f:
-        model_list = json.load(f)
-        
-    list_of_clusters = get_cluster_list(model_list)
-    uncertainty_form_clusters(list_of_clusters)
+    model_list = inventory.get_uncertainty_models()
+    cluster_list = get_cluster_list(model_list)
+    uncertainty_form_clusters(cluster_list)
 
 
 # A recurrent job

--- a/data-api/app/controllers/uncertainty_mean_sample_agent.py
+++ b/data-api/app/controllers/uncertainty_mean_sample_agent.py
@@ -8,37 +8,44 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from sandu.data_types import UncertaintyInput
 
 import app.controllers.uncertainty_analysis.uncertainty_mean_sample as ums
+import app.controllers.uncertainty_analysis.uncertainty_model_inventory as inventory
 
 from app.core.settings import DATA_PATH_LIVE
 
 
-def compute_mean_sample():
-    """Computes the mean of a group of time series and draws a random sample for plotting.
+def compute_mean_sample(input_filename, output_filename):
+    """Computes the mean of a group of time series and draws a random sample from the ensemble.
     """
-    folder = Path(DATA_PATH_LIVE)
-    filename = folder / "models/uncertainty/example/raw.json"
-    output_filename = folder / "models/uncertainty/example/mean_all.json"
 
     # Check if file exists
-    if not filename.is_file():
-        print("CANNOT FIND ", filename)
+    if not input_filename.is_file():
+        print("CANNOT FIND ", input_filename)
         return
 
-    with open(filename, "r") as read_file:
+    with open(input_filename, "r") as read_file:
         x = json.load(read_file, object_hook=lambda d: UncertaintyInput(**d))
         data_dict = ums.mean_and_sample(x)
     with open(output_filename, "w", encoding="utf-8") as f:
         ujson.dump(data_dict, f, ensure_ascii=False, indent=4)
 
 
+def mean_sample_agent():
+    model_list = inventory.get_uncertainty_models()
+    for model in model_list:
+        folder = Path(DATA_PATH_LIVE)
+        input_filename = folder / str("models/uncertainty/" + model["name"] + "/raw.json")
+        output_filename = folder / str("models/uncertainty/" + model["name"] + "/mean_all.json")
+        compute_mean_sample(input_filename, output_filename)
+
+
 # A recurrent job
 scheduler = BackgroundScheduler(daemon=True)
 
 # Cron runs at 1am daily
-scheduler.add_job(compute_mean_sample, "cron", hour=1, minute=0, second=0)
+scheduler.add_job(mean_sample_agent, "cron", hour=1, minute=0, second=0)
 
 scheduler.start()
 logger.info('Uncertainty-mean-sample-analysis agent starts. Will run immediately now and every 1am.')
 
 # Run immediately after server starts
-threading.Thread(target=compute_mean_sample).start()
+threading.Thread(target=mean_sample_agent).start()

--- a/data-api/manifest/urls.json
+++ b/data-api/manifest/urls.json
@@ -10,6 +10,11 @@
         "save_to": "models/uncertainty/example"
     },
     {
+        "name": "Uncertainty invntory",
+        "url": "https://gist.githubusercontent.com/rampvisdevelopment/52a5836735eff0d33692cfd06d049197/raw/uncertainty_inventory.json",
+        "save_to": "models/uncertainty/uncertainty_inventory.json"
+    },
+    {
         "name": "ensemble",
         "url": "https://github.com/rampvisdevelopment/ensemble/archive/master.zip",
         "save_to": "ensemble"

--- a/data-api/manifest/urls.json
+++ b/data-api/manifest/urls.json
@@ -10,7 +10,7 @@
         "save_to": "models/uncertainty/example"
     },
     {
-        "name": "Uncertainty invntory",
+        "name": "uncertainty inventory",
         "url": "https://gist.githubusercontent.com/rampvisdevelopment/52a5836735eff0d33692cfd06d049197/raw/uncertainty_inventory.json",
         "save_to": "models/uncertainty/uncertainty_inventory.json"
     },


### PR DESCRIPTION
The models present for uncertainty analysis are now specified in uncertainty_inventory which is downloaded from [here](https://gist.github.com/rampvisdevelopment/52a5836735eff0d33692cfd06d049197) rather than hard coded. Thus more models and different clusters can be added easily. I have tested that adding another dataset work with this method.